### PR TITLE
ClojureScript support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.2.0 - ClojureScript support
+* Added configuration to start a CLJS repl inside Atom
+* Added code to differentiate between Clojure and ClojureScript
+* Possibility to force Clojure or ClojureScript
+* More info on statusbar
+* New commands:
+  * evaluate-block
+  * evaluate-selection
+* Watches in ClojureScript
+* Renamed --check-deps-- ns (problems with CLJS)
+
 ## 0.1.2 - Bugfix
 * Fixed cases when the first exception was being repeated when running code multiple times
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.2 - Bugfix
+* Fixed cases when the first exception was being repeated when running code multiple times
+
 ## 0.1.2 - Fix on EVRY and Simple Refresh
 * Simple refresh option on settings
 * Fixed simple refresh causing an exception when there's no namespace in file

--- a/lib/clj-commands.coffee
+++ b/lib/clj-commands.coffee
@@ -14,12 +14,16 @@ module.exports = class CljCommands
     if !@cljs
       code = atom.config.get('clojure-plus.cljsCommand')
       @promisedRepl.clear()
-      @promisedRepl.syncRun(code, 'user', session: 'cljs').then (e) ->
-        console.log "LOADED CLJS"
-      @cljs = true
-    code = @getFile("~/.atom/packages/clojure-plus/lib/clj/check_deps.clj")
-    code = "(in-ns '--check-deps--) (def last-exception (atom nil))"
-    @promisedRepl.syncRun(code, 'cljs.user', session: 'cljs')
+      @promisedRepl.syncRun(code, 'user', session: 'cljs').then (e) =>
+        @promisedRepl.syncRun("(ns __check.deps__)", '__check.deps__', session: 'cljs')
+        @promisedRepl.syncRun("(def last-exception (atom nil))", '__check.deps__', session: 'cljs')
+        @promisedRepl.syncRun("(def watches (atom {}))", '__check.deps__', session: 'cljs')
+        if e.value
+          if atom.config.get('clojure-plus.notify')
+            atom.notifications.addSuccess("Loaded ClojureScript REPL")
+        else
+          atom.notifications.addError("Error loading ClojureScript", detail: e.error)
+        @cljs = true
 
   prepare: ->
     code = @getFile("~/.atom/packages/clojure-plus/lib/clj/check_deps.clj")
@@ -95,7 +99,7 @@ module.exports = class CljCommands
   # TODO: Move me to MarkerCollection
   assignWatches: ->
     @runBefore()
-    @promisedRepl.syncRun("(def __watches__ (atom {}))", 'user').then =>
+    @promisedRepl.syncRun("(reset! __check.deps__/watches {})", 'user').then =>
       for id, mark of @watches
         delete @watches[id] unless mark.isValid()
         ns = @repl.EditorUtils.findNsDeclaration(mark.editor)
@@ -110,7 +114,7 @@ module.exports = class CljCommands
               '"'
 
     if varName
-      text = "(--check-deps--/goto-var '#{varName} #{tmpPath})"
+      text = "(__check.deps__/goto-var '#{varName} #{tmpPath})"
 
       @promisedRepl.runCodeInCurrentNS(text).then (result) =>
         if result.value
@@ -126,13 +130,13 @@ module.exports = class CljCommands
     fs.readFileSync(fileName).toString()
 
   nsForMissing: (symbolName) ->
-    @promisedRepl.runCodeInCurrentNS("(--check-deps--/resolve-missing \"#{symbolName}\")")
+    @promisedRepl.runCodeInCurrentNS("(__check.deps__/resolve-missing \"#{symbolName}\")")
 
   unusedImports: (filePath) ->
     filePath = filePath.replace(/"/g, '\\\\').replace(/\\/g, '\\\\')
-    @promisedRepl.runCodeInCurrentNS("(--check-deps--/unused-namespaces \"#{filePath}\")")
+    @promisedRepl.runCodeInCurrentNS("(__check.deps__/unused-namespaces \"#{filePath}\")")
 
   getSymbolsInEditor: (editor) ->
-    @promisedRepl.runCodeInCurrentNS("(--check-deps--/symbols-from-ns-in-json *ns*)").then (result) =>
+    @promisedRepl.runCodeInCurrentNS("(__check.deps__/symbols-from-ns-in-json *ns*)").then (result) =>
       return unless result.value
       JSON.parse(result.value)

--- a/lib/clj-commands.coffee
+++ b/lib/clj-commands.coffee
@@ -4,12 +4,26 @@ PromisedRepl = require './promised-repl'
 MarkerCollection = require './marker-collection'
 
 module.exports = class CljCommands
+  cljs: false
+
   constructor: (@watches, @repl) ->
     @promisedRepl = new PromisedRepl(@repl)
-    @markers = window.mf = new MarkerCollection(@watches)
+    @markers = new MarkerCollection(@watches)
+
+  prepareCljs: ->
+    if !@cljs
+      code = atom.config.get('clojure-plus.cljsCommand')
+      @promisedRepl.clear()
+      @promisedRepl.syncRun(code, 'user', session: 'cljs').then (e) ->
+        console.log "LOADED CLJS"
+      @cljs = true
+    code = @getFile("~/.atom/packages/clojure-plus/lib/clj/check_deps.clj")
+    code = "(in-ns '--check-deps--) (def last-exception (atom nil))"
+    @promisedRepl.syncRun(code, 'cljs.user', session: 'cljs')
 
   prepare: ->
     code = @getFile("~/.atom/packages/clojure-plus/lib/clj/check_deps.clj")
+    @cljs = false
     @promisedRepl.clear()
     @promisedRepl.syncRun(code, 'user')
 

--- a/lib/clj/check_deps.clj
+++ b/lib/clj/check_deps.clj
@@ -183,3 +183,5 @@ this very simple code:
     (cons '-> (f code nil))))
 
 (def last-exception (atom nil))
+
+(def watches (atom {}))

--- a/lib/clj/check_deps.clj
+++ b/lib/clj/check_deps.clj
@@ -1,4 +1,4 @@
-(ns --check-deps--
+(ns __check.deps__
   (:require [clojure.test :refer :all]))
 
 (defn vars-in-form [form vars]

--- a/lib/clj/check_deps_test.clj
+++ b/lib/clj/check_deps_test.clj
@@ -1,6 +1,6 @@
 (ns check-deps.test
   (:require [clojure.test :refer :all]
-            [--check-deps-- :refer :all]))
+            [__check.deps__ :refer :all]))
 
 (testing "tracing a clojure command"
   (is (= {:fn "clojure.core/conj"

--- a/lib/clojure-plus.coffee
+++ b/lib/clojure-plus.coffee
@@ -343,8 +343,9 @@ module.exports =
     pr = @getCommands().promisedRepl
     pr.syncRun('(map (fn [[k v]] (str k "#" (with-out-str (print-method v *out*)))) @__check.deps__/watches)',
       "user").then (result) => @updateInAtom(result)
-    pr.syncRun('(map (fn [[k v]] (str k "#" v)) @__check.deps__/watches)',
-      "user", session: "cljs").then (result) => @updateInAtom(result)
+    if @getCommands().cljs
+      pr.syncRun('(map (fn [[k v]] (str k "#" v)) @__check.deps__/watches)',
+        "user", session: "cljs").then (result) => @updateInAtom(result)
 
   updateInAtom: (result) ->
     console.log "HANDLER", result

--- a/lib/clojure-plus.coffee
+++ b/lib/clojure-plus.coffee
@@ -8,55 +8,7 @@ highlight = require './sexp-highlight'
 MarkerCollection = require './marker-collection'
 
 module.exports =
-  config:
-    highlightSexp:
-      description: "Highlight current SEXP under cursor"
-      type: "boolean"
-      default: false
-    notify:
-      description: "Notify when refresh was done"
-      type: "boolean"
-      default: true
-    simpleRefresh:
-      description: "Refresh with a very simple code (that requires the current namespace)"
-      type: "boolean"
-      default: false
-    refreshAfterConnect:
-      description: "Refresh after REPL is connected"
-      type: "boolean"
-      default: true
-    refreshAfterSave:
-      description: "Refresh after saving a file"
-      type: "boolean"
-      default: true
-    afterRefreshCmd:
-      description: "Command to run after each refresh (success or failure)"
-      type: 'string'
-      default: "(alter-var-root #'clojure.test/*load-tests* (constantly true))"
-    beforeRefreshCmd:
-      description: "Command to run before each refresh (success or failure)"
-      type: 'string'
-      default: "(alter-var-root #'clojure.test/*load-tests* (constantly false))"
-    refreshAllCmd:
-      description: "Path to a file with the refresh all namespaces' command"
-      type: 'string'
-      default: "~/.atom/packages/clojure-plus/lib/clj/refresh_all.clj"
-    refreshCmd:
-      description: "Path to a file with the refresh namespaces' command"
-      type: 'string'
-      default: "~/.atom/packages/clojure-plus/lib/clj/refresh.clj"
-    clearRepl:
-      description: "Clear REPL before running a command"
-      type: 'boolean'
-      default: false
-    openPending:
-      description: "When opening a file with Goto Var Definition, keep tab as pending"
-      type: 'boolean'
-      default: true
-    tempDir:
-      description: "Temporary directory to unpack JAR files (used by goto-var)"
-      type: "string"
-      default: "/tmp/jar-path"
+  config: require('./configs')
 
   currentWatches: {}
   lastClear: null

--- a/lib/clojure-plus.coffee
+++ b/lib/clojure-plus.coffee
@@ -294,15 +294,16 @@ module.exports =
         editor: editor
         range: range
 
-    # @getCommands().promisedRepl.clear()
-    @getCommands().promisedRepl.syncRun("(do (in-ns 'user) (def __watches__ (atom {})))", 'user').then =>
+    @getCommands().promisedRepl.syncRun("(do (in-ns 'user)
+                                             (def __watches__ (atom {}))
+                                             (reset! --check-deps--/last-exception nil))", 'user').then =>
       @getCommands().promisedRepl.syncRun(text, options).then (result) =>
         if result.value
           options.displayInRepl = true
           options.resultHandler = protoRepl.repl.inlineResultHandler
           protoRepl.repl.inlineResultHandler(result, options)
         else
-          @getCommands().promisedRepl.syncRun('@--check-deps--/last-exception', session: 'exceptions').then (result) =>
+          @getCommands().promisedRepl.runCodeInCurrentNS('@--check-deps--/last-exception', session: 'exceptions').then (result) =>
             value = protoRepl.parseEdn(result.value) if result.value
             @makeErrorInline(value, editor, range) if value
 

--- a/lib/clojure-plus.coffee
+++ b/lib/clojure-plus.coffee
@@ -83,6 +83,15 @@ module.exports =
       if item instanceof TextEditor
         @checkRefreshMode(atom.config.get("clojure-plus.simpleRefresh"), item)
 
+    @subs.add atom.commands.add 'atom-text-editor', 'clojure-plus:toggle-clojure-and-clojurescript', =>
+      editor = atom.workspace.getActiveTextEditor()
+      mode = @evalModes.get(editor.getBuffer().id)
+      if mode == 'cljs'
+        @evalModes.set(editor.getBuffer().id, 'clojure')
+      else
+        @evalModes.set(editor.getBuffer().id, 'cljs')
+      @checkRefreshMode(atom.config.get("clojure-plus.simpleRefresh"), editor)
+
     grammarCode = (editor, {name}) =>
       if editor.getFileName()?.endsWith(".cljs")
         @evalModes.set(editor.getBuffer().id, 'cljs')
@@ -232,7 +241,7 @@ module.exports =
 
     if editor = atom.workspace.getActiveTextEditor()
       if range = protoRepl.EditorUtils.getCursorInBlockRange(editor, topLevel: true)
-        session = 'cljs' if @evalModes.get(item.getBuffer().id) == 'cljs'
+        session = 'cljs' if @evalModes.get(editor.getBuffer().id) == 'cljs'
         @runCodeInRange(editor, range, session)
 
   runCodeInRange: (editor, range, session) ->

--- a/lib/clojure-plus.coffee
+++ b/lib/clojure-plus.coffee
@@ -232,7 +232,7 @@ module.exports =
 
     if editor = atom.workspace.getActiveTextEditor()
       if range = protoRepl.EditorUtils.getCursorInBlockRange(editor, topLevel: true)
-        session = 'cljs' if editor.getFileName()?.endsWith(".cljs")
+        session = 'cljs' if @evalModes.get(item.getBuffer().id) == 'cljs'
         @runCodeInRange(editor, range, session)
 
   runCodeInRange: (editor, range, session) ->

--- a/lib/configs.coffee
+++ b/lib/configs.coffee
@@ -1,0 +1,53 @@
+module.exports =
+  highlightSexp:
+    description: "Highlight current SEXP under cursor"
+    type: "boolean"
+    default: false
+  notify:
+    description: "Notify when refresh was done"
+    type: "boolean"
+    default: true
+  simpleRefresh:
+    description: "Refresh with a very simple code (that requires the current namespace)"
+    type: "boolean"
+    default: false
+  refreshAfterConnect:
+    description: "Refresh after REPL is connected"
+    type: "boolean"
+    default: true
+  refreshAfterSave:
+    description: "Refresh after saving a file"
+    type: "boolean"
+    default: true
+  afterRefreshCmd:
+    description: "Command to run after each refresh (success or failure)"
+    type: 'string'
+    default: "(alter-var-root #'clojure.test/*load-tests* (constantly true))"
+  beforeRefreshCmd:
+    description: "Command to run before each refresh (success or failure)"
+    type: 'string'
+    default: "(alter-var-root #'clojure.test/*load-tests* (constantly false))"
+  refreshAllCmd:
+    description: "Path to a file with the refresh all namespaces' command"
+    type: 'string'
+    default: "~/.atom/packages/clojure-plus/lib/clj/refresh_all.clj"
+  refreshCmd:
+    description: "Path to a file with the refresh namespaces' command"
+    type: 'string'
+    default: "~/.atom/packages/clojure-plus/lib/clj/refresh.clj"
+  clearRepl:
+    description: "Clear REPL before running a command"
+    type: 'boolean'
+    default: false
+  openPending:
+    description: "When opening a file with Goto Var Definition, keep tab as pending"
+    type: 'boolean'
+    default: true
+  cljsCommand:
+    description: "Clojure command to open ClojureScript's REPL"
+    type: 'string'
+    default: "(use 'figwheel-sidecar.repl-api) (start-figwheel!) (figwheel-sidecar.repl-api/cljs-repl)"
+  tempDir:
+    description: "Temporary directory to unpack JAR files (used by goto-var)"
+    type: "string"
+    default: "/tmp/jar-path"

--- a/lib/evry-provider.coffee
+++ b/lib/evry-provider.coffee
@@ -5,7 +5,7 @@ code = "(map (fn [e]
                 :column (:column e)
                 :fqpath (:fqpath e)
                 :queryString (str (:fqname e) (:file e))})
-             (--check-deps--/symbols-in-project))"
+             (__check.deps__/symbols-in-project))"
 
 module.exports = class EvryProvider
   name: "clj-symbols"

--- a/lib/promised-repl.coffee
+++ b/lib/promised-repl.coffee
@@ -25,12 +25,15 @@ module.exports = class PromisedRepl
       lastPromise.then(f)
       lastPromise.catch(f)
 
-  runCodeInCurrentNS: (code) ->
+  runCodeInCurrentNS: (code, opts={}) ->
     new Promise (resolve) =>
-      @repl.executeCodeInNs code, displayInRepl: false, resultHandler: (result) =>
-        resolve(result)
+      opts.displayInRepl = false
+      opts.resultHandler = (result) => resolve(result)
+      @repl.executeCodeInNs code, opts
 
-  runCodeInNS: (code, ns) ->
+  runCodeInNS: (code, ns, opts={}) ->
     new Promise (resolve) =>
-      @repl.executeCode code, displayInRepl: false, ns: ns, resultHandler: (result) =>
-        resolve(result)
+      opts.displayInRepl = false
+      opts.resultHandler = (result) => resolve(result)
+      opts.ns = ns
+      @repl.executeCode code, opts

--- a/styles/clojure-plus.less
+++ b/styles/clojure-plus.less
@@ -17,3 +17,7 @@ div.ink.error {
   a { color: #cc0000; }
   .fade { color: #999999; }
 }
+
+status-bar div.clojure-plus {
+  font-style: italic;
+}


### PR DESCRIPTION
* Added configuration to start a CLJS repl inside Atom
* Added code to differentiate between Clojure and ClojureScript
* Possibility to force Clojure or ClojureScript
* More info on statusbar
* New commands:
  * evaluate-block
  * evaluate-selection
* Watches in ClojureScript
* Renamed --check-deps-- ns (problems with CLJS)

Problems yet to be solved:
1. ClojureScript will not connect to console
1. ClojureScript stacktrace is not (and probably will never be) implemented 
    1. Browsers are strange when sourcemap enters in the game
    1. ClojureScript dislikes `ns`, `load-namespace` and other forms inside `try`... `catch` or `do`
1. I'm starting to miss tests...