### PR TITLE
Simple helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .DS_Store
 npm-debug.log
 node_modules
+.lein*
+.nrepl*
+target

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Refresh will now clear dependency cache. This means that refresh will recover from fatal error in more cases
 * Added option "invert stacktrace" - better debugging or errors
 * Corrected some errors with stacktrace parsing
+* Corrected mark current SEXP
 
 ## 0.2.0 - ClojureScript support
 * Added configuration to start a CLJS repl inside Atom

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2 - More helpers
+* Added "interrupt" command. It'll delegate to proto but will not lock anymore our execution context
+* Refresh will now clear dependency cache. This means that refresh will recover from fatal error in more cases
+
 ## 0.2.0 - ClojureScript support
 * Added configuration to start a CLJS repl inside Atom
 * Added code to differentiate between Clojure and ClojureScript

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Added "interrupt" command. It'll delegate to proto but will not lock anymore our execution context
 * Refresh will now clear dependency cache. This means that refresh will recover from fatal error in more cases
 * Added option "invert stacktrace" - better debugging or errors
+* Corrected some errors with stacktrace parsing
 
 ## 0.2.0 - ClojureScript support
 * Added configuration to start a CLJS repl inside Atom

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.2.2 - More helpers
 * Added "interrupt" command. It'll delegate to proto but will not lock anymore our execution context
 * Refresh will now clear dependency cache. This means that refresh will recover from fatal error in more cases
+* Added option "invert stacktrace" - better debugging or errors
 
 ## 0.2.0 - ClojureScript support
 * Added configuration to start a CLJS repl inside Atom

--- a/lib/clj-commands.coffee
+++ b/lib/clj-commands.coffee
@@ -15,9 +15,9 @@ module.exports = class CljCommands
       code = atom.config.get('clojure-plus.cljsCommand')
       @promisedRepl.clear()
       @promisedRepl.syncRun(code, 'user', session: 'cljs').then (e) =>
-        @promisedRepl.syncRun("(ns __check.deps__)", '__check.deps__', session: 'cljs')
-        @promisedRepl.syncRun("(def last-exception (atom nil))", '__check.deps__', session: 'cljs')
-        @promisedRepl.syncRun("(def watches (atom {}))", '__check.deps__', session: 'cljs')
+        @promisedRepl.syncRun("(ns clj.--check-deps--)", 'clj.--check-deps--', session: 'cljs')
+        @promisedRepl.syncRun("(def last-exception (atom nil))", 'clj.--check-deps--', session: 'cljs')
+        @promisedRepl.syncRun("(def watches (atom {}))", 'clj.--check-deps--', session: 'cljs')
         if e.value
           if atom.config.get('clojure-plus.notify')
             atom.notifications.addSuccess("Loaded ClojureScript REPL")
@@ -26,7 +26,7 @@ module.exports = class CljCommands
         @cljs = true
 
   prepare: ->
-    code = @getFile("~/.atom/packages/clojure-plus/lib/clj/check_deps.clj")
+    code = @getFile("~/.atom/packages/clojure-plus/lib/clj/__check_deps__.clj")
     @cljs = false
     @promisedRepl.clear()
     @promisedRepl.syncRun(code, 'user')
@@ -99,7 +99,7 @@ module.exports = class CljCommands
   # TODO: Move me to MarkerCollection
   assignWatches: ->
     @runBefore()
-    @promisedRepl.syncRun("(reset! __check.deps__/watches {})", 'user').then =>
+    @promisedRepl.syncRun("(reset! clj.--check-deps--/watches {})", 'user').then =>
       for id, mark of @watches
         delete @watches[id] unless mark.isValid()
         ns = @repl.EditorUtils.findNsDeclaration(mark.editor)
@@ -114,7 +114,7 @@ module.exports = class CljCommands
               '"'
 
     if varName
-      text = "(__check.deps__/goto-var '#{varName} #{tmpPath})"
+      text = "(clj.--check-deps--/goto-var '#{varName} #{tmpPath})"
 
       @promisedRepl.runCodeInCurrentNS(text).then (result) =>
         if result.value
@@ -130,13 +130,13 @@ module.exports = class CljCommands
     fs.readFileSync(fileName).toString()
 
   nsForMissing: (symbolName) ->
-    @promisedRepl.runCodeInCurrentNS("(__check.deps__/resolve-missing \"#{symbolName}\")")
+    @promisedRepl.runCodeInCurrentNS("(clj.--check-deps--/resolve-missing \"#{symbolName}\")")
 
   unusedImports: (filePath) ->
     filePath = filePath.replace(/"/g, '\\\\').replace(/\\/g, '\\\\')
-    @promisedRepl.runCodeInCurrentNS("(__check.deps__/unused-namespaces \"#{filePath}\")")
+    @promisedRepl.runCodeInCurrentNS("(clj.--check-deps--/unused-namespaces \"#{filePath}\")")
 
   getSymbolsInEditor: (editor) ->
-    @promisedRepl.runCodeInCurrentNS("(__check.deps__/symbols-from-ns-in-json *ns*)").then (result) =>
+    @promisedRepl.runCodeInCurrentNS("(clj.--check-deps--/symbols-from-ns-in-json *ns*)").then (result) =>
       return unless result.value
       JSON.parse(result.value)

--- a/lib/clj/__check_deps__.clj
+++ b/lib/clj/__check_deps__.clj
@@ -1,4 +1,4 @@
-(ns __check.deps__
+(ns clj.--check-deps--
   (:require [clojure.test :refer :all]))
 
 (defn vars-in-form [form vars]

--- a/lib/clj/__check_deps__.clj
+++ b/lib/clj/__check_deps__.clj
@@ -75,7 +75,7 @@
 
 (def runtime (delay (clojure.lang.RT/baseLoader)))
 (defn get-full-path [file]
-  (some-> @runtime (.getResource file) .getPath))
+  (some->> file (.getResource @runtime) .getPath))
 
 (defn goto-var [var-sym temp-dir]
   (require 'clojure.repl)
@@ -138,24 +138,30 @@
     (clojure.string/split #"\$")))
 
 ;; Pretty stack traces
-(defn clj-trace [class-name line-number]
+(defn- correct-file-name [stack-file-name file-from-meta raw-ns-name fn-name]
+  (let [n (clojure.string/replace raw-ns-name #"\." "/")
+        from-ns-name #(or (get-full-path (str n ".clj"))
+                          (get-full-path (str n ".cljc"))
+                          (get-full-path (str n ".cljx"))
+                          (get-full-path (str n ".cljs"))
+                          (get-full-path (str n ".cljr")))]
+    (if (= fn-name "[anon-function]")
+      (from-ns-name)
+      (or (get-full-path file-from-meta) (from-ns-name)))))
+
+(defn clj-trace [class-name stack-file-name line-number]
   (let [[raw-ns-name _] (clojure.string/split class-name #"\$")
         [ns-name fn-name] (normalize-clj-name class-name)
         fq-symbol (ns-resolve (symbol ns-name) (symbol fn-name))
-        filename (:file (meta fq-symbol))
-        loader (clojure.lang.RT/baseLoader)
-        file-to-open (if filename
-                       (.getResource loader filename)
-                       (let [n (clojure.string/replace raw-ns-name #"\." "/")]
-                         (or (.getResource loader (str n ".clj"))
-                             (.getResource loader (str n ".cljc"))
-                             (.getResource loader (str n ".cljx"))
-                             (.getResource loader (str n ".cljs"))
-                             (.getResource loader (str n ".cljr")))))
-        file-to-open (when file-to-open (.getPath file-to-open))]
+        fn-name (cond
+                  (re-matches #"eval\d+" fn-name) "[inline-eval]"
+                  (re-matches #"^fn$" fn-name) "[anon-function]"
+                  :else fn-name)
+        file-from-meta (when-not (= fn-name "[anon-function]") (:file (meta fq-symbol)))
+        file-to-open (correct-file-name stack-file-name file-from-meta raw-ns-name fn-name)]
 
-    {:fn (str ns-name "/" (if (re-matches #"eval\d+" fn-name) "[inline-eval]" fn-name))
-     :file (or filename (some-> file-to-open (clojure.string/replace #".*!/?" "")))
+    {:fn (str ns-name "/" fn-name)
+     :file (or file-from-meta (some-> file-to-open (clojure.string/replace #".*!/?" "")))
      :line line-number
      :link file-to-open}))
 
@@ -174,7 +180,7 @@ this very simple code:
         clj-file? (re-find #"\.clj[cxs]?$" filename)]
 
     (if clj-file?
-      (clj-trace (.getClassName stack-line) (.getLineNumber stack-line))
+      (clj-trace (.getClassName stack-line) (.getFileName stack-line) (.getLineNumber stack-line))
       (other-trace stack-line))))
 
 (defn to-thread [code]

--- a/lib/clj/check_deps_test.clj
+++ b/lib/clj/check_deps_test.clj
@@ -1,6 +1,6 @@
-(ns check-deps.test
+(ns clj.check-deps-test
   (:require [clojure.test :refer :all]
-            [__check.deps__ :refer :all]))
+            [clj.--check-deps-- :refer :all]))
 
 (testing "tracing a clojure command"
   (is (= {:fn "clojure.core/conj"

--- a/lib/clj/check_deps_test.clj
+++ b/lib/clj/check_deps_test.clj
@@ -6,21 +6,12 @@
   (is (= {:fn "clojure.core/conj"
           :file "clojure/core.clj"
           :line 20}
-         (dissoc (clj-trace "clojure.core$conj__1234" 20) :link))))
+         (dissoc (clj-trace "clojure.core$conj__1234" "core.clj" 20) :link))))
 
 (testing "traces a function with strange name"
   (is (= "clojure.core/conj"
-         (:fn (clj-trace "clojure.core$eval1020$conj__1234" 20))))
+         (:fn (clj-trace "clojure.core$eval1020$conj__1234" "core.clj" 20))))
 
-  (is (= {:fn ""
-          :file "clj/check_deps_test"
-          :line 19}
-        (clj-trace "clj.check_deps_test$eval39348$fn__39349$fn__39350$fn__39351" 19))))
-
-(try
-  ((fn []
-     ((fn [a b]
-        (/ a b))
-      10 0)))
-  (catch Exception e
-    (->> (.getStackTrace e) (into []))))
+  (let [{:keys [fn file]} (clj-trace "clj.check_deps_test$eval39348$fn__39349$fn__39350$fn__39351" "core.clj" 19)]
+    (is (= "clj.check-deps-test/[anon-function]" fn)
+        (re-find #"check_deps_test" file))))

--- a/lib/clj/check_deps_test.clj
+++ b/lib/clj/check_deps_test.clj
@@ -9,4 +9,18 @@
          (dissoc (clj-trace "clojure.core$conj__1234" 20) :link))))
 
 (testing "traces a function with strange name"
-  (is (= "clojure.core/conj" (:fn (clj-trace "clojure.core$eval1020$conj__1234" 20)))))
+  (is (= "clojure.core/conj"
+         (:fn (clj-trace "clojure.core$eval1020$conj__1234" 20))))
+
+  (is (= {:fn ""
+          :file "clj/check_deps_test"
+          :line 19}
+        (clj-trace "clj.check_deps_test$eval39348$fn__39349$fn__39350$fn__39351" 19))))
+
+(try
+  ((fn []
+     ((fn [a b]
+        (/ a b))
+      10 0)))
+  (catch Exception e
+    (->> (.getStackTrace e) (into []))))

--- a/lib/clj/refresh_all.clj
+++ b/lib/clj/refresh_all.clj
@@ -1,3 +1,4 @@
 (do
   (require '[clojure.tools.namespace.repl :as repl])
+  (repl/clear)
   (repl/refresh-all))

--- a/lib/clojure-plus.coffee
+++ b/lib/clojure-plus.coffee
@@ -338,11 +338,19 @@ module.exports =
     causeHtml = document.createElement('strong')
     causeHtml.classList.add('error-description')
     causeHtml.innerText = cause
+    invert = atom.config.get("clojure-plus.invertStack")
 
-    strTrace = cause + "\n"
+    strTrace = cause
+    if invert
+      strTrace = "\n" + strTrace
+    else
+      strTrace += "\n"
 
     traceHtmls = trace.map (row) =>
-      strTrace += "\n\tin #{row.fn}\n\tat #{row.file}:#{row.line}\n"
+      if invert
+        strTrace = "\n\tin #{row.fn}\n\tat #{row.file}:#{row.line}\n" + strTrace
+      else
+        strTrace += "\n\tin #{row.fn}\n\tat #{row.file}:#{row.line}\n"
 
       div = document.createElement('div')
       div.classList.add('trace-entry')

--- a/lib/clojure-plus.coffee
+++ b/lib/clojure-plus.coffee
@@ -21,6 +21,8 @@ module.exports =
     @subs = new CompositeDisposable()
     @subs.add atom.commands.add 'atom-text-editor', 'clojure-plus:refresh-namespaces', =>
       @getCommands().runRefresh()
+    @subs.add atom.commands.add 'atom-text-editor', 'clojure-plus:refresh-namespaces', =>
+      @interrupt()
     @subs.add atom.commands.add 'atom-text-editor', 'clojure-plus:toggle-simple-refresh', =>
       atom.config.set('clojure-plus.simpleRefresh', !atom.config.get('clojure-plus.simpleRefresh'))
     @subs.add atom.commands.add 'atom-text-editor', 'clojure-plus:goto-var-definition', =>
@@ -133,6 +135,10 @@ module.exports =
       editor = atom.workspace.getActiveTextEditor()
       [range, symbol] = @getRangeAndVar(editor)
       protoRepl.executeCodeInNs("`" + symbol, inlineOptions: {editor: editor, range: range})
+
+  interrupt: ->
+    protoRepl.interrupt()
+    @getCommands().promisedRepl.clear()
 
   importForMissing: ->
       editor = atom.workspace.getActiveTextEditor()

--- a/lib/clojure-plus.coffee
+++ b/lib/clojure-plus.coffee
@@ -74,7 +74,7 @@ module.exports =
                                      ..COL..
                                      \" => \"
                                      __sel__)
-                            (swap! __check.deps__/watches update-in [..ID..] (fn [x] (conj (or x []) __sel__)))
+                            (swap! clj.--check-deps--/watches update-in [..ID..] (fn [x] (conj (or x []) __sel__)))
                             __sel__)"
 
     @addWatcher "def-local-symbols", "(do (doseq [__s__ (refactor-nrepl.find.find-locals/find-used-locals {:file ..FILE_NAME..
@@ -292,8 +292,8 @@ module.exports =
     options.session = session if session?
     @getCommands().prepareCljs() if session == 'cljs'
 
-    @getCommands().promisedRepl.syncRun("(reset! __check.deps__/watches {})", 'user', session: session)
-    @getCommands().promisedRepl.syncRun("(reset! __check.deps__/last-exception nil)", 'user')
+    @getCommands().promisedRepl.syncRun("(reset! clj.--check-deps--/watches {})", 'user', session: session)
+    @getCommands().promisedRepl.syncRun("(reset! clj.--check-deps--/last-exception nil)", 'user')
     @runCode(text, options, session)
 
   runCode: (text, options, session) ->
@@ -306,7 +306,7 @@ module.exports =
         options.resultHandler = protoRepl.repl.inlineResultHandler
         protoRepl.repl.inlineResultHandler(result, options)
       else if session != 'cljs'
-        @getCommands().promisedRepl.runCodeInCurrentNS('@__check.deps__/last-exception').then (res2) =>
+        @getCommands().promisedRepl.runCodeInCurrentNS('@clj.--check-deps--/last-exception').then (res2) =>
           value = protoRepl.parseEdn(res2.value) if res2.value
           value = {cause: result.error, trace: []} if !value
           @makeErrorInline(value, editor, range)
@@ -322,9 +322,9 @@ module.exports =
     else
       "(try #{text}\n(catch Exception e
         (do
-          (reset! __check.deps__/last-exception
+          (reset! clj.--check-deps--/last-exception
             {:cause (str e)
-             :trace (map __check.deps__/prettify-stack (.getStackTrace e))}))
+             :trace (map clj.--check-deps--/prettify-stack (.getStackTrace e))}))
           (throw e)))"
 
   makeErrorInline: ({cause, trace}, editor, range) ->
@@ -362,8 +362,8 @@ module.exports =
           if row.link.match(/\.jar!/)
             tmp = atom.config.get('clojure-plus.tempDir').replace(/\\/g, "\\\\").replace(/"/g, "\\\"") +
             saneLink = row.link.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
-            code = "(let [[_ & jar-data] (__check.deps__/extract-jar-data \"#{saneLink}\")]
-                      (__check.deps__/decompress-all \"#{tmp}\" jar-data))"
+            code = "(let [[_ & jar-data] (clj.--check-deps--/extract-jar-data \"#{saneLink}\")]
+                      (clj.--check-deps--/decompress-all \"#{tmp}\" jar-data))"
             @getCommands().promisedRepl.syncRun(code).then (result) =>
               return unless result.value
               atom.workspace.open(protoRepl.parseEdn(result.value), searchAllPanes: true, initialLine: row.line-1)
@@ -388,10 +388,10 @@ module.exports =
 
   handleWatches: ->
     pr = @getCommands().promisedRepl
-    pr.syncRun('(map (fn [[k v]] (str k "#" (with-out-str (print-method v *out*)))) @__check.deps__/watches)',
+    pr.syncRun('(map (fn [[k v]] (str k "#" (with-out-str (print-method v *out*)))) @clj.--check-deps--/watches)',
       "user").then (result) => @updateInAtom(result)
     if @getCommands().cljs
-      pr.syncRun('(map (fn [[k v]] (str k "#" v)) @__check.deps__/watches)',
+      pr.syncRun('(map (fn [[k v]] (str k "#" v)) @clj.--check-deps--/watches)',
         "user", session: "cljs").then (result) => @updateInAtom(result)
 
   updateInAtom: (result) ->

--- a/lib/clojure-plus.coffee
+++ b/lib/clojure-plus.coffee
@@ -21,7 +21,7 @@ module.exports =
     @subs = new CompositeDisposable()
     @subs.add atom.commands.add 'atom-text-editor', 'clojure-plus:refresh-namespaces', =>
       @getCommands().runRefresh()
-    @subs.add atom.commands.add 'atom-text-editor', 'clojure-plus:refresh-namespaces', =>
+    @subs.add atom.commands.add 'atom-text-editor', 'clojure-plus:interrupt', =>
       @interrupt()
     @subs.add atom.commands.add 'atom-text-editor', 'clojure-plus:toggle-simple-refresh', =>
       atom.config.set('clojure-plus.simpleRefresh', !atom.config.get('clojure-plus.simpleRefresh'))

--- a/lib/configs.coffee
+++ b/lib/configs.coffee
@@ -51,3 +51,7 @@ module.exports =
     description: "Temporary directory to unpack JAR files (used by goto-var)"
     type: "string"
     default: "/tmp/jar-path"
+  invertStack:
+    description: "Inverts stacktrace showing on console"
+    type: 'boolean'
+    default: true

--- a/lib/evry-provider.coffee
+++ b/lib/evry-provider.coffee
@@ -5,7 +5,7 @@ code = "(map (fn [e]
                 :column (:column e)
                 :fqpath (:fqpath e)
                 :queryString (str (:fqname e) (:file e))})
-             (__check.deps__/symbols-in-project))"
+             (clj.--check-deps--/symbols-in-project))"
 
 module.exports = class EvryProvider
   name: "clj-symbols"

--- a/lib/sexp-highlight.coffee
+++ b/lib/sexp-highlight.coffee
@@ -4,10 +4,12 @@ disposables = new CompositeDisposable
 marks = []
 
 fn = (editor) =>
-  mark = editor.markBufferRange([0,0], invalidate: 'never')
-  marks.push(mark)
+  mark = marks[editor.id]
+  if !mark
+    mark = editor.markBufferRange([0,0], invalidate: 'never')
+    marks[editor.id] = mark
+    editor.decorateMarker(mark, type: 'highlight', class: 'clojure-sexp')
 
-  editor.decorateMarker(mark, type: 'highlight', class: 'clojure-sexp')
   disposables.add editor.onDidChangeCursorPosition =>
     unless editor.getGrammar().scopeName.match(/clojure/)
       mark.setBufferRange([0,0])
@@ -22,7 +24,8 @@ module.exports = (willObserve) ->
     disposables.add atom.workspace.observeTextEditors(fn)
     atom.workspace.getTextEditors().forEach(fn)
   else
-    marks.forEach (m) -> m.destroy()
-    marks = []
+    for _, m of marks
+      m.destroy()
+    marks = {}
     disposables.dispose()
     disposables.clear()

--- a/project.clj
+++ b/project.clj
@@ -1,0 +1,3 @@
+(defproject clojure-plus "0.0.1-SNAPSHOT"
+  :dependencies [[org.clojure/clojure "1.8.0"]]
+  :source-paths ["lib"])

--- a/styles/clojure-plus.less
+++ b/styles/clojure-plus.less
@@ -9,7 +9,7 @@ atom-text-editor::shadow {
   }
 
   .clojure-sexp .region {
-    background-color: rgba(255, 255, 255, 0.05);
+    background-color: rgba(255, 255, 255, 0.15);
   }
 }
 


### PR DESCRIPTION
## Changes

  * Added "interrupt" command. It'll delegate to proto but will not lock anymore our execution context
  * Refresh will now clear dependency cache. This means that refresh will recover from fatal error in more cases
  * Added option "invert stacktrace" - better debugging or errors
  * Corrected some errors with stacktrace parsing

