### PR TITLE
Correct path on Windoes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.3 - Bugfix on Windows
+* Removed dependency from HOME env variable (fixes
+[#19](https://github.com/mauricioszabo/clojure-plus/issues/19))
+* Refresh and Refresh-all are now commands instead of files
+
 ## 0.2.2 - More helpers
 * Added "interrupt" command. It'll delegate to proto but will not lock anymore our execution context
 * Refresh will now clear dependency cache. This means that refresh will recover from fatal error in more cases

--- a/lib/clj-commands.coffee
+++ b/lib/clj-commands.coffee
@@ -26,7 +26,7 @@ module.exports = class CljCommands
         @cljs = true
 
   prepare: ->
-    code = @getFile("~/.atom/packages/clojure-plus/lib/clj/__check_deps__.clj")
+    code = @getFile("~/lib/clj/__check_deps__.clj")
     @cljs = false
     @promisedRepl.clear()
     @promisedRepl.syncRun(code, 'user')
@@ -72,6 +72,7 @@ module.exports = class CljCommands
 
     notify = atom.config.get('clojure-plus.notify')
     @promisedRepl.syncRun(refreshCmd, "user").then (result) =>
+      console.log result
       if result.value
         value = @repl.parseEdn(result.value)
         if !value.cause
@@ -94,7 +95,7 @@ module.exports = class CljCommands
 
   getRefreshCmd: (all) ->
     key = if all then 'clojure-plus.refreshAllCmd' else 'clojure-plus.refreshCmd'
-    @getFile(atom.config.get(key))
+    atom.config.get(key)
 
   # TODO: Move me to MarkerCollection
   assignWatches: ->
@@ -125,8 +126,7 @@ module.exports = class CljCommands
           @repl.stderr("Error trying to open: #{result.error}")
 
   getFile: (file) ->
-    home = process.env.HOME
-    fileName = file.replace("~", home)
+    fileName = file.replace("~", atom.packages.getActivePackage('clojure-plus').path)
     fs.readFileSync(fileName).toString()
 
   nsForMissing: (symbolName) ->

--- a/lib/clj/refresh.clj
+++ b/lib/clj/refresh.clj
@@ -1,3 +1,0 @@
-(do
-  (require '[clojure.tools.namespace.repl :as repl])
-  (repl/refresh))

--- a/lib/clj/refresh_all.clj
+++ b/lib/clj/refresh_all.clj
@@ -1,4 +1,0 @@
-(do
-  (require '[clojure.tools.namespace.repl :as repl])
-  (repl/clear)
-  (repl/refresh-all))

--- a/lib/configs.coffee
+++ b/lib/configs.coffee
@@ -28,13 +28,13 @@ module.exports =
     type: 'string'
     default: "(alter-var-root #'clojure.test/*load-tests* (constantly false))"
   refreshAllCmd:
-    description: "Path to a file with the refresh all namespaces' command"
+    description: "Clear and refresh all namespaces command"
     type: 'string'
-    default: "~/.atom/packages/clojure-plus/lib/clj/refresh_all.clj"
+    default: "(do (require '[clojure.tools.namespace.repl :as repl]) (repl/clear) (repl/refresh-all))"
   refreshCmd:
-    description: "Path to a file with the refresh namespaces' command"
+    description: "Refresh namespaces command"
     type: 'string'
-    default: "~/.atom/packages/clojure-plus/lib/clj/refresh.clj"
+    default: "(do (require '[clojure.tools.namespace.repl :as repl]) (repl/refresh))"
   clearRepl:
     description: "Clear REPL before running a command"
     type: 'boolean'


### PR DESCRIPTION
On Linux, our package was being identified by **HOME** env variable. This doesn't work on Windows, so we're using atom's API now. This means that, in config file, `~` now means PACKAGE PATH.